### PR TITLE
Expose a typesafe way to get global variables

### DIFF
--- a/src/War3Api.Common/Common/Lua.cs
+++ b/src/War3Api.Common/Common/Lua.cs
@@ -17,5 +17,26 @@ namespace War3Api
     {
         /// @CSharpLua.Template = "FourCC({0})"
         public static extern int FourCC(string value);
+        
+        /// <summary>
+        /// Get a global variable matching the given key.
+        /// </summary>
+        /// <typeparam name="T">The type of the global variable.</typeparam>
+        /// <returns>
+        /// The value of global variable
+        /// </returns>
+        public static T GetGlobal<T>(string key)
+        {
+            // NOTE: The comments below are important. Please don't remove.
+            // The Lua generator will inject the commented code and comment
+            // out the C# return statement.
+
+            /*[[
+            return rawget(System.global, key)
+            --[[
+            ]]*/
+            return default(T);
+            //]]
+        }
     }
 }


### PR DESCRIPTION
Using [CSharp.lua's method of inserting Lua code](https://github.com/yanghuan/CSharp.lua/wiki/FAQ_en#7how-do-you-call-or-insert-lua-code-in-your-code), we can leverage that to allow access to global variables from C#.