### PR TITLE
Update .gitignore to include folder containing Warcraft 3 game data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,4 @@ healthchecksdb
 /src/War3Api.Blizzard/Generated
 /src/War3Api.Common/Generated
 /src/War3Api.Object/Generated
+/src/War3Api.Generator.Object/API


### PR DESCRIPTION
Contributors need to include their own Warcraft 3 data in War3Api.Generator.Object/API to run the War3Api.Generator.Object project. That data can't be uploaded publicly, so it should be gitignored.