### PR TITLE
Warcraft 3 1.32 compatibility

### DIFF
--- a/src/War3Api.Generator.Object/ModelService.cs
+++ b/src/War3Api.Generator.Object/ModelService.cs
@@ -100,6 +100,8 @@ namespace War3Api.Generator.Object
             yield return GenerateTypeListModel("buffList", "Buff"); // TODO: validate buffs are all buff (rawcode starts with B, with some exceptions where it starts with A)
             yield return GenerateTypeListModel("effectList", "Buff"); // TODO: validate buffs are all effect (rawcode starts with X)
             yield return GenerateTypeListModel("heroAbilityList", "Ability"); // TODO: validate abilities are all hero abil
+            yield return GenerateTypeListModel("abilitySkinList", "Ability");
+            yield return GenerateTypeListModel("unitSkinList", "Unit");
             yield return GenerateTypeListModel("intList", GetKeywordText(SyntaxKind.IntKeyword));
             yield return GenerateTypeListModel("itemList", "Item");
             yield return GenerateTypeListModel("lightningList", "LightningEffect");

--- a/src/War3Api.Generator.Object/ObjectApiGenerator.cs
+++ b/src/War3Api.Generator.Object/ObjectApiGenerator.cs
@@ -539,15 +539,7 @@ namespace War3Api.Generator.Object
                                 var splitPosition = line.IndexOf('=', StringComparison.Ordinal);
                                 var key = line.Substring(0, splitPosition);
                                 var value = line.Substring(splitPosition + 1);
-                                if (!worldEditStrings.TryAdd(key, value))
-                                {
-                                    if (worldEditStrings[key] == value)
-                                    {
-                                        continue;
-                                    }
-
-                                    throw new Exception($"Key {key} already added:\r\nWas '{worldEditStrings[key]}'\r\nTried to add '{value}'");
-                                }
+                                worldEditStrings.TryAdd(key, value);
                             }
                         }
                     }


### PR DESCRIPTION
This makes War3Api.Generator.Object compatible with Warcraft 3 1.32 game data by:

- Including "abilitySkinList" and "unitSkinList" in ModelService
- Removing an exception thrown when editor data has duplicate keys (since Warcraft 3 1.32 editor data has duplicate keys in it)