### PR TITLE
Add the ability to cast from ObjectModification to BaseObject-derived classes

### DIFF
--- a/src/War3Api.Generator.Object/Classes/BaseObject.cs
+++ b/src/War3Api.Generator.Object/Classes/BaseObject.cs
@@ -5,40 +5,35 @@ namespace War3Api.Object
     // todo: generate through code (since it's similar to Unit/Ability/etc)
     public abstract class BaseObject
     {
-        private readonly ObjectDatabase _db;
+        private ObjectDatabase _db;
 
-        internal BaseObject(int oldId, ObjectDatabase db = null)
+        internal BaseObject(int oldId)
         {
             OldId = oldId;
             NewId = 0;
-
-            _db = db ?? ObjectDatabase.DefaultDatabase;
-            _db.AddObject(this);
         }
 
-        internal BaseObject(int oldId, int newId, ObjectDatabase db = null)
+        internal BaseObject(int oldId, int newId)
         {
             OldId = oldId;
             NewId = newId;
-
-            _db = db ?? ObjectDatabase.DefaultDatabase;
-            _db.AddObject(this);
         }
 
-        internal BaseObject(int oldId, string newRawcode, ObjectDatabase db = null)
+        internal BaseObject(int oldId, string newRawcode)
         {
             OldId = oldId;
             NewId = newRawcode.FromRawcode();
-
-            _db = db ?? ObjectDatabase.DefaultDatabase;
-            _db.AddObject(this);
         }
 
         public int OldId { get; }
 
         public int NewId { get; }
 
-        public ObjectDatabase Db => _db;
+        public ObjectDatabase Db
+        {
+            get => _db;
+            internal set => _db = value;
+        }
 
         public int Key => NewId != 0 ? NewId : OldId;
     }

--- a/src/War3Api.Generator.Object/Classes/ListExtensions.cs
+++ b/src/War3Api.Generator.Object/Classes/ListExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using War3Net.Build.Object;
+
+namespace War3Api.Object
+{
+    public static class ListExtensions
+    {
+        /// <summary>
+        /// Convert into a SimpleObjectDataModifications, copying over all data.
+        /// </summary>
+        /// <param name="list"></param>
+        /// <returns></returns>
+        public static SimpleObjectDataModifications ToSimpleObjectDataModifications(this List<SimpleObjectDataModification> list)
+        {
+            SimpleObjectDataModifications simpleObjectDataModifications = new();
+            foreach (var mod in list)
+            {
+                simpleObjectDataModifications[mod.Id] = mod;
+            }
+            return simpleObjectDataModifications;
+        }
+    }
+}

--- a/src/War3Api.Generator.Object/Classes/ListExtensions.cs
+++ b/src/War3Api.Generator.Object/Classes/ListExtensions.cs
@@ -10,7 +10,7 @@ namespace War3Api.Object
         /// </summary>
         /// <param name="list"></param>
         /// <returns></returns>
-        public static SimpleObjectDataModifications ToSimpleObjectDataModifications(this List<SimpleObjectDataModification> list)
+        public static SimpleObjectDataModifications ToObjectDataModifications(this List<SimpleObjectDataModification> list)
         {
             SimpleObjectDataModifications simpleObjectDataModifications = new();
             foreach (var mod in list)
@@ -18,6 +18,36 @@ namespace War3Api.Object
                 simpleObjectDataModifications[mod.Id] = mod;
             }
             return simpleObjectDataModifications;
+        }
+
+        /// <summary>
+        /// Convert into a LevelObjectDataModifications, copying over all data.
+        /// </summary>
+        /// <param name="list"></param>
+        /// <returns></returns>
+        public static LevelObjectDataModifications ToObjectDataModifications(this List<LevelObjectDataModification> list)
+        {
+            LevelObjectDataModifications levelObjectDataModifications = new();
+            foreach (var mod in list)
+            {
+                levelObjectDataModifications[mod.Id] = mod;
+            }
+            return levelObjectDataModifications;
+        }
+
+        /// <summary>
+        /// Convert into a VariationObjectDataModifications, copying over all data.
+        /// </summary>
+        /// <param name="list"></param>
+        /// <returns></returns>
+        public static VariationObjectDataModifications ToObjectDataModifications(this List<VariationObjectDataModification> list)
+        {
+            VariationObjectDataModifications variationObjectDataModifications = new();
+            foreach (var mod in list)
+            {
+                variationObjectDataModifications[mod.Id] = mod;
+            }
+            return variationObjectDataModifications;
         }
     }
 }

--- a/src/War3Api.Generator.Object/Classes/ObjectDatabase.cs
+++ b/src/War3Api.Generator.Object/Classes/ObjectDatabase.cs
@@ -12,7 +12,6 @@ namespace War3Api.Object
 {
     public sealed class ObjectDatabase
     {
-        private static readonly Lazy<ObjectDatabase> _defaultDatabase = new Lazy<ObjectDatabase>();
         private static readonly Lazy<HashSet<int>> _objectTypes = new Lazy<HashSet<int>>(() => GetObjectTypes().ToHashSet());
         private static readonly Lazy<HashSet<int>> _techTypes = new Lazy<HashSet<int>>(() => GetTechTypes().ToHashSet());
 
@@ -41,8 +40,6 @@ namespace War3Api.Object
             _reservedTechs = new HashSet<int>();
             _objects = objects.ToDictionary(obj => obj.Key);
         }
-
-        public static ObjectDatabase DefaultDatabase => _defaultDatabase.Value;
 
         public Unit GetUnit(int id)
         {
@@ -240,7 +237,12 @@ namespace War3Api.Object
             };
         }
 
-        internal void AddObject(BaseObject baseObject)
+        /// <summary>
+        /// Add a Unit, Ability, Destructable, Doodad, etc to this object database.
+        /// </summary>
+        /// <param name="baseObject"></param>
+        /// <exception cref="InvalidOperationException">Thrown if baseObject is a member of another ObjectDatabase.</exception>
+        public void AddObject(BaseObject baseObject)
         {
             if (_objects.ContainsKey(baseObject.Key))
             {
@@ -300,7 +302,12 @@ namespace War3Api.Object
                 }
             }
 
+            if (baseObject.Db != null)
+            {
+                throw new InvalidOperationException($"{baseObject.Key.ToRawcode()} is already in a database.");
+            }
             _objects.Add(baseObject.Key, baseObject);
+            baseObject.Db = this;
         }
 
         internal void ReserveTech(int id)

--- a/src/War3Api.Generator.Object/Classes/Tech.cs
+++ b/src/War3Api.Generator.Object/Classes/Tech.cs
@@ -6,7 +6,7 @@ namespace War3Api.Object
 {
     public class Tech
     {
-        private readonly ObjectDatabase _db;
+        private ObjectDatabase _db;
         private readonly int _key;
 
         public Tech(Unit unit)
@@ -42,11 +42,6 @@ namespace War3Api.Object
             _key = (int)techEquivalent;
         }
 
-        public Tech(int key)
-            : this(ObjectDatabase.DefaultDatabase, key)
-        {
-        }
-
         public Tech(ObjectDatabase db, int key)
         {
             if (db is null)
@@ -67,7 +62,11 @@ namespace War3Api.Object
             _key = key;
         }
 
-        public ObjectDatabase Db => _db;
+        public ObjectDatabase Db
+        {
+            get => _db;
+            internal set => _db = value;
+        }
 
         public int Key => _key;
 

--- a/src/War3Api.Generator.Object/ObjectApiGenerator.cs
+++ b/src/War3Api.Generator.Object/ObjectApiGenerator.cs
@@ -175,7 +175,7 @@ namespace War3Api.Generator.Object
                 { "Ability", false },
                 { "Buff", null },
                 { "Upgrade", false },
-            }; 
+            };
 
             return GetProperties(className, properties, mapToUsesVariationBool[className], isAbstractClass, null);
         }
@@ -247,6 +247,24 @@ namespace War3Api.Generator.Object
                             $"new {className}({objectVariableName}.OldId, {objectVariableName}.NewId) {{ Modifications = {objectVariableName}.Modifications.ToObjectDataModifications() }}")),
                         SyntaxFactory.Token(SyntaxKind.SemicolonToken));
                 }
+            }
+            else
+            {
+                //Explit conversion from SimpleObjectModification to a class that pre-specifies a value, such as a concrete implementation of Ability.
+                var objectVariableName = char.ToLowerInvariant(objectTypeName[0]) + objectTypeName[1..];
+                yield return SyntaxFactory.ConversionOperatorDeclaration(
+                    default,
+                    SyntaxFactory.TokenList(
+                        SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+                        SyntaxFactory.Token(SyntaxKind.StaticKeyword)),
+                    SyntaxFactory.Token(SyntaxKind.ExplicitKeyword),
+                    SyntaxFactory.Token(SyntaxKind.OperatorKeyword),
+                    SyntaxFactory.ParseTypeName(className),
+                    SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Parameter(default, default, SyntaxFactory.ParseTypeName(objectTypeName), SyntaxFactory.Identifier(objectVariableName), null))),
+                    null,
+                    SyntaxFactory.ArrowExpressionClause(SyntaxFactory.ParseExpression(
+                        $"new {className}({objectVariableName}.NewId) {{ Modifications = {objectVariableName}.Modifications.ToObjectDataModifications() }}")),
+                    SyntaxFactory.Token(SyntaxKind.SemicolonToken));
             }
 
             var typeDict = _typeModels.ToDictionary(type => type.Name);

--- a/src/War3Api.Generator.Object/ObjectApiGenerator.cs
+++ b/src/War3Api.Generator.Object/ObjectApiGenerator.cs
@@ -230,20 +230,23 @@ namespace War3Api.Generator.Object
                         $"new {objectTypeName} {{ OldId = {classVariableName}.OldId, NewId = {classVariableName}.NewId, Modifications = {classVariableName}.Modifications.ToList() }}")),
                     SyntaxFactory.Token(SyntaxKind.SemicolonToken));
                 //Explicit conversion from SimpleObjectModification to the BaseObject-derived class.
-                var objectVariableName = char.ToLowerInvariant(objectTypeName[0]) + objectTypeName[1..];
-                yield return SyntaxFactory.ConversionOperatorDeclaration(
-                    default,
-                    SyntaxFactory.TokenList(
-                        SyntaxFactory.Token(SyntaxKind.PublicKeyword),
-                        SyntaxFactory.Token(SyntaxKind.StaticKeyword)),
-                    SyntaxFactory.Token(SyntaxKind.ExplicitKeyword),
-                    SyntaxFactory.Token(SyntaxKind.OperatorKeyword),
-                    SyntaxFactory.ParseTypeName(className),
-                    SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Parameter(default, default, SyntaxFactory.ParseTypeName(objectTypeName), SyntaxFactory.Identifier(objectVariableName), null))),
-                    null,
-                    SyntaxFactory.ArrowExpressionClause(SyntaxFactory.ParseExpression(
-                        $"new {className}({objectVariableName}.OldId, {objectVariableName}.NewId) {{ Modifications = {objectVariableName}.Modifications.ToSimpleObjectDataModifications() }}")),
-                    SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+                if (!isAbstractClass)
+                {
+                    var objectVariableName = char.ToLowerInvariant(objectTypeName[0]) + objectTypeName[1..];
+                    yield return SyntaxFactory.ConversionOperatorDeclaration(
+                        default,
+                        SyntaxFactory.TokenList(
+                            SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+                            SyntaxFactory.Token(SyntaxKind.StaticKeyword)),
+                        SyntaxFactory.Token(SyntaxKind.ExplicitKeyword),
+                        SyntaxFactory.Token(SyntaxKind.OperatorKeyword),
+                        SyntaxFactory.ParseTypeName(className),
+                        SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Parameter(default, default, SyntaxFactory.ParseTypeName(objectTypeName), SyntaxFactory.Identifier(objectVariableName), null))),
+                        null,
+                        SyntaxFactory.ArrowExpressionClause(SyntaxFactory.ParseExpression(
+                            $"new {className}({objectVariableName}.OldId, {objectVariableName}.NewId) {{ Modifications = {objectVariableName}.Modifications.ToSimpleObjectDataModifications() }}")),
+                        SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+                }
             }
 
             var typeDict = _typeModels.ToDictionary(type => type.Name);

--- a/src/War3Api.Generator.Object/ObjectApiGenerator.cs
+++ b/src/War3Api.Generator.Object/ObjectApiGenerator.cs
@@ -244,7 +244,7 @@ namespace War3Api.Generator.Object
                         SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Parameter(default, default, SyntaxFactory.ParseTypeName(objectTypeName), SyntaxFactory.Identifier(objectVariableName), null))),
                         null,
                         SyntaxFactory.ArrowExpressionClause(SyntaxFactory.ParseExpression(
-                            $"new {className}({objectVariableName}.OldId, {objectVariableName}.NewId) {{ Modifications = {objectVariableName}.Modifications.ToSimpleObjectDataModifications() }}")),
+                            $"new {className}({objectVariableName}.OldId, {objectVariableName}.NewId) {{ Modifications = {objectVariableName}.Modifications.ToObjectDataModifications() }}")),
                         SyntaxFactory.Token(SyntaxKind.SemicolonToken));
                 }
             }

--- a/src/War3Api.Generator.Object/SyntaxFactoryService.cs
+++ b/src/War3Api.Generator.Object/SyntaxFactoryService.cs
@@ -103,13 +103,17 @@ namespace War3Api.Generator.Object
                         SyntaxFactory.VariableDeclarator(identifier))));
         }
 
-        internal static FieldDeclarationSyntax Field(string type, string identifier, ExpressionSyntax expression, SyntaxKind accessModifier = SyntaxKind.PrivateKeyword)
+        internal static FieldDeclarationSyntax Field(string type, string identifier, ExpressionSyntax expression, SyntaxKind accessModifier = SyntaxKind.PrivateKeyword, bool isReadOnly = true)
         {
+            var tokenList = isReadOnly
+                ? SyntaxFactory.TokenList(
+                    SyntaxFactory.Token(accessModifier),
+                    SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword))
+                : SyntaxTokenList.Create(SyntaxFactory.Token(accessModifier));
+
             return SyntaxFactory.FieldDeclaration(
                 default,
-                SyntaxFactory.TokenList(
-                    SyntaxFactory.Token(accessModifier),
-                    SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)),
+                SyntaxFactory.TokenList(tokenList),
                 SyntaxFactory.VariableDeclaration(
                     SyntaxFactory.ParseTypeName(type),
                     default(SeparatedSyntaxList<VariableDeclaratorSyntax>).Add(


### PR DESCRIPTION
This adds the ability to cast from ObjectModification to BaseObject-derived classes, except for Ability.

I had to make a significant compromise to achieve this; namely, I removed the default ObjectDatabase and gave responsibility of BaseObject data management to the ObjectDatabase class. This means that BaseObjects can be treated as data containers with no responsibility, such that they can be both read to and written from. As a positive side effect, this means that BaseObject has a dumb constructor.

I appreciate that I may or may not have executed this in the matter that you would prefer, but I went ahead anyway because I'm extremely enthusiastic about seeing such a feature implemented.

closes #9 